### PR TITLE
Fix the duplicate files error

### DIFF
--- a/rpm/goinstall.sh
+++ b/rpm/goinstall.sh
@@ -70,7 +70,7 @@ GOPATH=$PWD/_build golist \
 	--ignore-trees "${ignore_trees}" \
 	--ignore-regex "${ignore_regex}" \
 ); do
-	installfile ${file}
+	installfile ./${file}
 done
 # Process user specified resources
 for file in $@; do


### PR DESCRIPTION
Currently, goinstall generates duplicate files in the devel.file-list, see for example:

```
%%dir "//usr/share/gocode/src/bazil.org/fuse"
/usr/share/gocode/src/bazil.org/fuse/./buffer.go
/usr/share/gocode/src/bazil.org/fuse/buffer.go
/usr/share/gocode/src/bazil.org/fuse//builddir/build/BUILD/fuse-371fbbdaa8987b715bdd21d6adc4c9b20155f748/_build/src/bazil.org/fuse
/usr/share/gocode/src/bazil.org/fuse/./debug.go
/usr/share/gocode/src/bazil.org/fuse/debug.go
/usr/share/gocode/src/bazil.org/fuse/./error_darwin.go
/usr/share/gocode/src/bazil.org/fuse/./error_freebsd.go
/usr/share/gocode/src/bazil.org/fuse/./error_linux.go
/usr/share/gocode/src/bazil.org/fuse/error_linux.go
/usr/share/gocode/src/bazil.org/fuse/./error_std.go
/usr/share/gocode/src/bazil.org/fuse/error_std.go
/usr/share/gocode/src/bazil.org/fuse/examples/clockfs/clockfs.go
/usr/share/gocode/src/bazil.org/fuse/examples/hellofs/hello.go
/usr/share/gocode/src/bazil.org/fuse/fs/bench/bench_create_test.go
/usr/share/gocode/src/bazil.org/fuse/fs/bench/bench_lookup_test.go
/usr/share/gocode/src/bazil.org/fuse/fs/bench/bench_readwrite_test.go
/usr/share/gocode/src/bazil.org/fuse/./fs/bench/doc.go
/usr/share/gocode/src/bazil.org/fuse/fs/bench/doc.go
/usr/share/gocode/src/bazil.org/fuse/./fs/fstestutil/checkdir.go
/usr/share/gocode/src/bazil.org/fuse/fs/fstestutil/checkdir.go
/usr/share/gocode/src/bazil.org/fuse/./fs/fstestutil/debug.go
/usr/share/gocode/src/bazil.org/fuse/fs/fstestutil/debug.go
/usr/share/gocode/src/bazil.org/fuse/./fs/fstestutil/doc.go
/usr/share/gocode/src/bazil.org/fuse/fs/fstestutil/doc.go
/usr/share/gocode/src/bazil.org/fuse/./fs/fstestutil/mounted.go
/usr/share/gocode/src/bazil.org/fuse/fs/fstestutil/mounted.go
/usr/share/gocode/src/bazil.org/fuse/./fs/fstestutil/mountinfo_darwin.go
/usr/share/gocode/src/bazil.org/fuse/./fs/fstestutil/mountinfo_freebsd.go
/usr/share/gocode/src/bazil.org/fuse/./fs/fstestutil/mountinfo.go
/usr/share/gocode/src/bazil.org/fuse/fs/fstestutil/mountinfo.go
/usr/share/gocode/src/bazil.org/fuse/./fs/fstestutil/mountinfo_linux.go
/usr/share/gocode/src/bazil.org/fuse/fs/fstestutil/mountinfo_linux.go
/usr/share/gocode/src/bazil.org/fuse/./fs/fstestutil/record/buffer.go
/usr/share/gocode/src/bazil.org/fuse/fs/fstestutil/record/buffer.go
/usr/share/gocode/src/bazil.org/fuse/./fs/fstestutil/record/record.go
/usr/share/gocode/src/bazil.org/fuse/fs/fstestutil/record/record.go
/usr/share/gocode/src/bazil.org/fuse/./fs/fstestutil/record/wait.go
/usr/share/gocode/src/bazil.org/fuse/fs/fstestutil/record/wait.go
/usr/share/gocode/src/bazil.org/fuse/./fs/fstestutil/testfs.go
/usr/share/gocode/src/bazil.org/fuse/fs/fstestutil/testfs.go
/usr/share/gocode/src/bazil.org/fuse/fs/helpers_test.go
/usr/share/gocode/src/bazil.org/fuse/./fs/serve.go
/usr/share/gocode/src/bazil.org/fuse/fs/serve.go
/usr/share/gocode/src/bazil.org/fuse/fs/serve_test.go
/usr/share/gocode/src/bazil.org/fuse/./fs/tree.go
/usr/share/gocode/src/bazil.org/fuse/fs/tree.go
/usr/share/gocode/src/bazil.org/fuse/./fuse_darwin.go
/usr/share/gocode/src/bazil.org/fuse/./fuse_freebsd.go
/usr/share/gocode/src/bazil.org/fuse/./fuse.go
/usr/share/gocode/src/bazil.org/fuse/fuse.go
/usr/share/gocode/src/bazil.org/fuse/./fuse_kernel_darwin.go
/usr/share/gocode/src/bazil.org/fuse/./fuse_kernel_freebsd.go
/usr/share/gocode/src/bazil.org/fuse/./fuse_kernel.go
/usr/share/gocode/src/bazil.org/fuse/fuse_kernel.go
/usr/share/gocode/src/bazil.org/fuse/./fuse_kernel_linux.go
/usr/share/gocode/src/bazil.org/fuse/fuse_kernel_linux.go
/usr/share/gocode/src/bazil.org/fuse/./fuse_kernel_std.go
/usr/share/gocode/src/bazil.org/fuse/fuse_kernel_std.go
/usr/share/gocode/src/bazil.org/fuse/fuse_kernel_test.go
/usr/share/gocode/src/bazil.org/fuse/./fuse_linux.go
/usr/share/gocode/src/bazil.org/fuse/fuse_linux.go
/usr/share/gocode/src/bazil.org/fuse/./fuseutil/fuseutil.go
/usr/share/gocode/src/bazil.org/fuse/fuseutil/fuseutil.go
/usr/share/gocode/src/bazil.org/fuse/./mount_darwin.go
/usr/share/gocode/src/bazil.org/fuse/./mount_freebsd.go
/usr/share/gocode/src/bazil.org/fuse/./mount.go
/usr/share/gocode/src/bazil.org/fuse/mount.go
/usr/share/gocode/src/bazil.org/fuse/./mount_linux.go
/usr/share/gocode/src/bazil.org/fuse/mount_linux.go
/usr/share/gocode/src/bazil.org/fuse/./options_darwin.go
/usr/share/gocode/src/bazil.org/fuse/./options_freebsd.go
/usr/share/gocode/src/bazil.org/fuse/./options.go
/usr/share/gocode/src/bazil.org/fuse/options.go
/usr/share/gocode/src/bazil.org/fuse/options_helper_test.go
/usr/share/gocode/src/bazil.org/fuse/./options_linux.go
/usr/share/gocode/src/bazil.org/fuse/options_linux.go
/usr/share/gocode/src/bazil.org/fuse/options_test.go
/usr/share/gocode/src/bazil.org/fuse/./protocol.go
/usr/share/gocode/src/bazil.org/fuse/protocol.go
/usr/share/gocode/src/bazil.org/fuse/./syscallx/doc.go
/usr/share/gocode/src/bazil.org/fuse/syscallx/doc.go
/usr/share/gocode/src/bazil.org/fuse/./syscallx/msync_386.go
/usr/share/gocode/src/bazil.org/fuse/./syscallx/msync_amd64.go
/usr/share/gocode/src/bazil.org/fuse/syscallx/msync_amd64.go
/usr/share/gocode/src/bazil.org/fuse/./syscallx/msync.go
/usr/share/gocode/src/bazil.org/fuse/syscallx/msync.go
/usr/share/gocode/src/bazil.org/fuse/./syscallx/syscallx.go
/usr/share/gocode/src/bazil.org/fuse/syscallx/syscallx.go
/usr/share/gocode/src/bazil.org/fuse/./syscallx/syscallx_std.go
/usr/share/gocode/src/bazil.org/fuse/syscallx/syscallx_std.go
/usr/share/gocode/src/bazil.org/fuse/./syscallx/xattr_darwin_386.go
/usr/share/gocode/src/bazil.org/fuse/./syscallx/xattr_darwin_amd64.go
/usr/share/gocode/src/bazil.org/fuse/./syscallx/xattr_darwin.go
/usr/share/gocode/src/bazil.org/fuse/./unmount.go
/usr/share/gocode/src/bazil.org/fuse/unmount.go
/usr/share/gocode/src/bazil.org/fuse/./unmount_linux.go
/usr/share/gocode/src/bazil.org/fuse/unmount_linux.go
/usr/share/gocode/src/bazil.org/fuse/./unmount_std.go
```

Some files are listed twice: one with a "./" directory and one without.
This is because files passed to "Process user specified resources" are preceded with "./" whereas files detected in "Process automatically detected resources" are not.

This simple fix prepend "./" to the files detected by golist so that they are no duplicates anymore.