### PR TITLE
Fix splitting of sub-import paths in separate packages

### DIFF
--- a/bin/go-rpm-integration
+++ b/bin/go-rpm-integration
@@ -109,7 +109,7 @@ fi
 
 shift
 
-if ! options=$(getopt -n $0 -o hi:yp:g:wb:d:t:r:e:o:v:a: \
+if ! options=$(getopt -n $0 -o hi:yp:g:wb:d:t:r:e:s:o:v:a: \
                       -l help,go-import-path: \
                       -l system-files,prefix:,go-path: \
                       -l workdir-files,go-build-path: \
@@ -226,12 +226,14 @@ fullprovides(){
 
 provides() {
 goipath="${1}"
+lockfile="${2}"
 fullprovides golang-ipath "${goipath}"
 for prov in $(\
   GOPATH="${prefix}${gopath}"      \
   golist --provided                \
-	 --package-path ${goipath} \
-         ${golistflags[$goipath]}         \
+         --package-path ${goipath} \
+         $(cat "${lockfile}")      \
+         ${golistflags[$goipath]}  \
   ); do
   fullprovides golang "${prov}"
 done
@@ -239,12 +241,14 @@ done
 
 requires() {
 goipath="${1}"
+lockfile="${2}"
 for req in $(\
   GOPATH="${prefix}${gopath}"      \
   golist --imported                \
-	 --package-path ${goipath} \
-	 --skip-self               \
-         ${golistflags[$goipath]}         \
+         --package-path ${goipath} \
+         --skip-self               \
+         $(cat "${lockfile}")      \
+         ${golistflags[$goipath]}  \
   ); do
   echo "golang($req)"
 done
@@ -254,17 +258,32 @@ done
 case $action in
   install)        [[ ${#goipathes[@]} -eq 0 ]] && exit 0
                   otherfiles=( $* )
+                  filelist="${PWD}/${filelist}"
                   install -m 0755   -vd "${prefix}${gopath}/src"
                   for goipath in ${goipathes[@]} ; do
                     echo "Installing: ${goipath}"
-                    if [[ ! -e  "${GO_BUILD_PATH}/src/${goipath}" ]] ; then
-                      install -m 0755 -vd "$(dirname   ${GO_BUILD_PATH}/src/${goipath})"
-                      ln -vfs "${sourcedir}"          "${GO_BUILD_PATH}/src/${goipath}"
+                    fakepath="${GO_BUILD_PATH}/src/${goipath}"
+                    fakeroot=$(dirname ${fakepath})
+                    if [[ ! -d ${fakeroot} ]] ; then
+                      install -m 0755 -vd "${fakeroot}"
+                    else
+                      symdir="${fakeroot}"
+                      until [[ -h "${symdir}" || \
+                                  "${symdir}" == "${GO_BUILD_PATH}/src" ]] ; do
+                        symdir=$(dirname ${symdir})
+                      done
+                      # The root exists but none of the parents is a symlink
+                      # → someone goinstalled a Go subpackage before
+                      # → the conflicting path can be removed without affecting
+                      # project sources
+                      [[ "${symdir}" == "${GO_BUILD_PATH}/src" ]] && rm -fr "${fakepath}"
                     fi
+                    [[ ! -d ${fakepath} ]] && ln -fs "${sourcedir}" "${fakepath}"
                     pushd "${GO_BUILD_PATH}/src/${goipath}" >/dev/null
-                      [[ ! -e .goipath ]] && touch .goipath
-                      golistfiles=$(listfiles "${goipath}")
-                      for file in ${golistfiles[@]} ${otherfiles[@]} .goipath ; do
+                      echo "${golistflags[$goipath]}" > .goflags
+                      touch -r "${sourcedir}" .goipath .goflags
+                      for file in .goipath .goflags \
+                                  $(listfiles "${goipath}") ${otherfiles[@]} ; do
                         installfile "${goipath}" "${file}"
                       done
                     popd >/dev/null
@@ -283,10 +302,10 @@ case $action in
                   done
                   while read lockfile ; do
                     dir=$(dirname "${lockfile}")
-                    provides "${dir#${prefix}${gopath}/src/}"
+                    provides "${dir#${prefix}${gopath}/src/}" "${lockfile%%\.goipath}.goflags"
                   done ;;
   requires)       while read lockfile ; do
                     dir=$(dirname "${lockfile}")
-                    requires "${dir#${prefix}${gopath}/src/}"
+                    requires "${dir#${prefix}${gopath}/src/}" "${lockfile%%\.goipath}.goflags"
                   done ;;
 esac

--- a/rpm/macros.d/macros.go-rpm
+++ b/rpm/macros.d/macros.go-rpm
@@ -112,17 +112,33 @@
 #
 # When invoked several times with different file list names, it will attribute
 # directories to the first file list that makes use of them only.
-%goinstall(i:p:g:b:d:t:r:e:s:o:) %{expand:
-%{!?-o*:%{?-i*:
-%if "%{-i*}" != "%{goipath}"
-  %define gofllprefix %gorpmname %{-i*}
-%endif}}
-go-rpm-integration install %{!?-i*:-i %{goipath}} \\
-                           %{!?-o*:-o %{?gofllprefix:%{gofllprefix}-}%{gofilelist}} \\
-                           %{!?-p*:-p %{buildroot}} %{!?-g*:-g %{gopath}} \\
-                           %{!?-b*:-b "$PWD/_build"} \\
-                           %{?**} %{?goinstallflags}
-}
+%goinstall(i:p:g:b:d:t:r:e:s:o:) %{expand:%{lua:
+local  maingoipath = rpm.expand("%{goipath}")
+local othergoipath = rpm.expand("%{?-i*}")
+local       output = rpm.expand("%{?-o*}")
+local    sourcedir = rpm.expand("%{?-s*}")
+local    buildpath = rpm.expand("%{?-b*}")
+local outputprefix = ""
+if    (sourcedir == "") then sourcedir = "${PWD}" end
+if    (buildpath == "") then buildpath = "${PWD}/_build" end
+if (othergoipath ~= "") then
+  outputprefix = rpm.expand("%gorpmname " .. othergoipath) .. "-"
+  local i
+  local subdir
+  subdir, i = string.gsub(othergoipath, "^" .. maingoipath, "")
+  if (i == 1) then sourcedir = sourcedir .. subdir end
+end
+if (othergoipath == "") then othergoipath = maingoipath end
+if       (output == "") then output = outputprefix .. rpm.expand("%{gofilelist}") end
+local command = 'go-rpm-integration install'
+command = command .. ' -i ' .. othergoipath
+command = command .. ' %{?**}'
+command = command .. ' -s ' .. sourcedir
+command = command .. ' -b ' .. buildpath
+command = command .. ' -o ' .. output
+command = command .. ' %{!?-p*:-p %{buildroot}} %{!?-g*:-g %{gopath}}'
+command = command .. ' %{?goinstallflags}'
+print(command)}}
 
 # Run go test %{gotestflags} on all subdirectories except for those filtered out
 # THIS MACRO IS OPT-OUT.


### PR DESCRIPTION
I needed to package a project subtree separately, as it pulled in problem dependencies, and the existing code proved totally broken in practice.

This fixed version works for me.

I honestly do not see the point of the last_goipath and golistflags[$_last_goipath] stuff from line 137 onwards. IMHO it adds a lot of complexity and there’s no way it can actually work as intended in presence of default exclusion flags. However, it didn't prevent my subpackaging as a separate import path so I let it in.

Please check again if you actually need this with the fix I'm posting here. If not, please remove the per-goipath array indexing and make back the -d and -t exclusion flags as relative to the project root.

With or without the per-goipath exclusion array this fix is needed for the logic to actually work



