### PR TITLE
macros.go-rpm: Support %gobuildroot without global %goipath

### DIFF
--- a/rpm/macros.d/macros.go-rpm
+++ b/rpm/macros.d/macros.go-rpm
@@ -55,7 +55,7 @@
   %{?-i*:goipath="%{-i*}"}
   %{?-b*:GO_BUILD_PATH="%{-b*}"}
   %{?-s*:sourcedir="%{-s*}"}
-  goipath="${goipath:-%{goipath}}"
+  goipath="${goipath:-%{?goipath}}"
   GO_BUILD_PATH="${GO_BUILD_PATH:-${PWD}/_build}"
   %global gobuildpath "$GO_BUILD_PATH"
   if [[ ! -e  "%{gobuildpath}/src/${goipath}" ]] ; then


### PR DESCRIPTION
For some complicated packages (such as Docker), there can be multiple Go buildroots in the same package.  In this case, it would be helpful to share the `%gobuildroot` code, but it currently expects to have a global `%goipath` definition due to the line

    goipath="${goipath:-%{goipath}}"

which expands to a bash expression `${goipath:-%{goipath}` when `%goipath` is undefined.  This is due to the shell not understanding nested braces, so there is an extra `}` on the symlink that breaks paths.

With this change, the undefined `%goipath` macro is dropped during expansion so the shell expression is evaluated as expected.  This allows multiple `%gobuildroot` uses in subshells with `-i`.